### PR TITLE
Add support for third-party PDSes

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,15 +1,10 @@
 """Bluesky/AT-Proto authentication for BookdIt."""
 import requests
-from atproto import models
 from atproto import Client as AtprotoClient
 from fasthtml.common import *
 from fastcore.xtras import flexicache, time_policy
 from typing import Optional, Dict, Any
-
-from uvicorn.protocols.http.flow_control import service_unavailable
-
 from components import Alert, NavBar
-import os
 import logging
 from dotenv import load_dotenv
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ atproto>=0.0.30
 python-dotenv>=1.0.0
 fastlite>=0.0.9
 fastmigrate>=0.3.0
+requests>=2.31.0


### PR DESCRIPTION
Currently, only users on a Bluesky mushroom (*.host.bsky.network) can sign in. This PR adds support for third-party PDSes by resolving the given handle to a DID doc and getting the listed serviceEndpoint.