### PR TITLE
feat(admin): add performance monitoring dashboard

### DIFF
--- a/bibliome/components/__init__.py
+++ b/bibliome/components/__init__.py
@@ -108,6 +108,12 @@ from .admin import (
     AdminDatabaseSection,
     DatabaseUploadForm,
     BackupHistoryCard,
+    PerformanceDashboard,
+    PerformanceOverviewCard,
+    PerformanceRouteTable,
+    PerformanceQueryTable,
+    PerformanceApiTable,
+    SlowRequestsList,
 )
 
 __all__ = [
@@ -195,4 +201,10 @@ __all__ = [
     "AdminDatabaseSection",
     "DatabaseUploadForm",
     "BackupHistoryCard",
+    "PerformanceDashboard",
+    "PerformanceOverviewCard",
+    "PerformanceRouteTable",
+    "PerformanceQueryTable",
+    "PerformanceApiTable",
+    "SlowRequestsList",
 ]

--- a/migrations/0011-add-performance-monitoring.sql
+++ b/migrations/0011-add-performance-monitoring.sql
@@ -1,0 +1,51 @@
+-- Migration to add performance monitoring tables
+-- Created: 2026-01-28
+
+-- Table to track request performance metrics
+CREATE TABLE IF NOT EXISTS request_metrics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    route TEXT NOT NULL,
+    method TEXT NOT NULL DEFAULT 'GET',
+    status_code INTEGER,
+    duration_ms REAL NOT NULL,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    user_did TEXT,
+    request_size INTEGER,
+    response_size INTEGER
+);
+
+-- Table to track slow database queries
+CREATE TABLE IF NOT EXISTS query_metrics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    query_type TEXT NOT NULL,  -- 'select', 'insert', 'update', 'delete'
+    query_name TEXT,  -- friendly name like 'get_public_shelves'
+    duration_ms REAL NOT NULL,
+    row_count INTEGER,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    caller TEXT  -- function name that executed the query
+);
+
+-- Table to track external API call performance
+CREATE TABLE IF NOT EXISTS api_metrics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    service TEXT NOT NULL,  -- 'google_books', 'bluesky', 'open_library'
+    endpoint TEXT NOT NULL,
+    duration_ms REAL NOT NULL,
+    status_code INTEGER,
+    success INTEGER NOT NULL DEFAULT 1,  -- 1 = success, 0 = failure
+    error_message TEXT,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes for better performance and querying
+CREATE INDEX IF NOT EXISTS idx_request_metrics_route ON request_metrics(route);
+CREATE INDEX IF NOT EXISTS idx_request_metrics_timestamp ON request_metrics(timestamp);
+CREATE INDEX IF NOT EXISTS idx_request_metrics_duration ON request_metrics(duration_ms);
+
+CREATE INDEX IF NOT EXISTS idx_query_metrics_name ON query_metrics(query_name);
+CREATE INDEX IF NOT EXISTS idx_query_metrics_timestamp ON query_metrics(timestamp);
+CREATE INDEX IF NOT EXISTS idx_query_metrics_duration ON query_metrics(duration_ms);
+
+CREATE INDEX IF NOT EXISTS idx_api_metrics_service ON api_metrics(service);
+CREATE INDEX IF NOT EXISTS idx_api_metrics_timestamp ON api_metrics(timestamp);
+CREATE INDEX IF NOT EXISTS idx_api_metrics_duration ON api_metrics(duration_ms);

--- a/performance_monitor.py
+++ b/performance_monitor.py
@@ -1,0 +1,713 @@
+"""Performance monitoring for tracking request, query, and API metrics."""
+
+import time
+import logging
+import threading
+import functools
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any, List, Callable
+from dataclasses import dataclass, field
+from collections import defaultdict
+from contextlib import contextmanager
+
+logger = logging.getLogger(__name__)
+
+# Global performance monitor instance
+_performance_monitor = None
+
+
+@dataclass
+class RequestMetric:
+    """Metric for a single HTTP request."""
+    route: str
+    method: str
+    status_code: Optional[int]
+    duration_ms: float
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    user_did: Optional[str] = None
+    request_size: Optional[int] = None
+    response_size: Optional[int] = None
+
+
+@dataclass
+class QueryMetric:
+    """Metric for a database query."""
+    query_type: str
+    query_name: Optional[str]
+    duration_ms: float
+    row_count: Optional[int] = None
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    caller: Optional[str] = None
+
+
+@dataclass
+class ApiMetric:
+    """Metric for an external API call."""
+    service: str
+    endpoint: str
+    duration_ms: float
+    status_code: Optional[int] = None
+    success: bool = True
+    error_message: Optional[str] = None
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+class PerformanceMonitor:
+    """Central performance monitoring service."""
+
+    # Threshold in ms for logging slow operations
+    SLOW_REQUEST_THRESHOLD_MS = 1000  # 1 second
+    SLOW_QUERY_THRESHOLD_MS = 100     # 100ms
+    SLOW_API_THRESHOLD_MS = 2000      # 2 seconds
+
+    # Maximum records to keep in database (for cleanup)
+    MAX_REQUEST_RECORDS = 50000
+    MAX_QUERY_RECORDS = 50000
+    MAX_API_RECORDS = 25000
+
+    def __init__(self, db_tables=None):
+        self.db_tables = db_tables
+        self._lock = threading.Lock()
+        self._request_buffer: List[RequestMetric] = []
+        self._query_buffer: List[QueryMetric] = []
+        self._api_buffer: List[ApiMetric] = []
+        self._buffer_size = 50  # Flush after this many records
+        self._enabled = True
+
+        # In-memory aggregates for quick stats
+        self._route_stats: Dict[str, Dict] = defaultdict(lambda: {
+            'count': 0, 'total_ms': 0, 'max_ms': 0, 'min_ms': float('inf')
+        })
+        self._query_stats: Dict[str, Dict] = defaultdict(lambda: {
+            'count': 0, 'total_ms': 0, 'max_ms': 0, 'min_ms': float('inf')
+        })
+        self._api_stats: Dict[str, Dict] = defaultdict(lambda: {
+            'count': 0, 'total_ms': 0, 'max_ms': 0, 'errors': 0
+        })
+
+        logger.info("Performance monitor initialized")
+
+    def set_db_tables(self, db_tables):
+        """Set database tables after initialization."""
+        self.db_tables = db_tables
+        self._ensure_tables()
+
+    def _ensure_tables(self):
+        """Ensure performance tables exist in db_tables."""
+        if not self.db_tables:
+            return
+
+        try:
+            from fastlite import Table
+            if 'request_metrics' not in self.db_tables:
+                self.db_tables['request_metrics'] = Table(
+                    self.db_tables['db'], 'request_metrics'
+                )
+            if 'query_metrics' not in self.db_tables:
+                self.db_tables['query_metrics'] = Table(
+                    self.db_tables['db'], 'query_metrics'
+                )
+            if 'api_metrics' not in self.db_tables:
+                self.db_tables['api_metrics'] = Table(
+                    self.db_tables['db'], 'api_metrics'
+                )
+        except Exception as e:
+            logger.warning(f"Could not ensure performance tables: {e}")
+
+    def record_request(self, route: str, method: str, status_code: int,
+                       duration_ms: float, user_did: Optional[str] = None,
+                       request_size: Optional[int] = None,
+                       response_size: Optional[int] = None):
+        """Record a request metric."""
+        if not self._enabled:
+            return
+
+        metric = RequestMetric(
+            route=route,
+            method=method,
+            status_code=status_code,
+            duration_ms=duration_ms,
+            user_did=user_did,
+            request_size=request_size,
+            response_size=response_size
+        )
+
+        # Update in-memory stats
+        key = f"{method} {route}"
+        with self._lock:
+            stats = self._route_stats[key]
+            stats['count'] += 1
+            stats['total_ms'] += duration_ms
+            stats['max_ms'] = max(stats['max_ms'], duration_ms)
+            stats['min_ms'] = min(stats['min_ms'], duration_ms)
+
+            self._request_buffer.append(metric)
+            if len(self._request_buffer) >= self._buffer_size:
+                self._flush_request_buffer()
+
+        # Log slow requests
+        if duration_ms >= self.SLOW_REQUEST_THRESHOLD_MS:
+            logger.warning(f"Slow request: {method} {route} took {duration_ms:.0f}ms")
+
+    def record_query(self, query_type: str, query_name: Optional[str],
+                     duration_ms: float, row_count: Optional[int] = None,
+                     caller: Optional[str] = None):
+        """Record a database query metric."""
+        if not self._enabled:
+            return
+
+        metric = QueryMetric(
+            query_type=query_type,
+            query_name=query_name,
+            duration_ms=duration_ms,
+            row_count=row_count,
+            caller=caller
+        )
+
+        # Update in-memory stats
+        key = query_name or query_type
+        with self._lock:
+            stats = self._query_stats[key]
+            stats['count'] += 1
+            stats['total_ms'] += duration_ms
+            stats['max_ms'] = max(stats['max_ms'], duration_ms)
+            stats['min_ms'] = min(stats['min_ms'], duration_ms)
+
+            self._query_buffer.append(metric)
+            if len(self._query_buffer) >= self._buffer_size:
+                self._flush_query_buffer()
+
+        # Log slow queries
+        if duration_ms >= self.SLOW_QUERY_THRESHOLD_MS:
+            logger.warning(f"Slow query: {query_name or query_type} took {duration_ms:.0f}ms")
+
+    def record_api_call(self, service: str, endpoint: str, duration_ms: float,
+                        status_code: Optional[int] = None, success: bool = True,
+                        error_message: Optional[str] = None):
+        """Record an external API call metric."""
+        if not self._enabled:
+            return
+
+        metric = ApiMetric(
+            service=service,
+            endpoint=endpoint,
+            duration_ms=duration_ms,
+            status_code=status_code,
+            success=success,
+            error_message=error_message
+        )
+
+        # Update in-memory stats
+        key = f"{service}:{endpoint}"
+        with self._lock:
+            stats = self._api_stats[key]
+            stats['count'] += 1
+            stats['total_ms'] += duration_ms
+            stats['max_ms'] = max(stats['max_ms'], duration_ms)
+            if not success:
+                stats['errors'] += 1
+
+            self._api_buffer.append(metric)
+            if len(self._api_buffer) >= self._buffer_size:
+                self._flush_api_buffer()
+
+        # Log slow API calls
+        if duration_ms >= self.SLOW_API_THRESHOLD_MS:
+            logger.warning(f"Slow API call: {service} {endpoint} took {duration_ms:.0f}ms")
+
+    def _flush_request_buffer(self):
+        """Flush request metrics to database."""
+        if not self.db_tables or not self._request_buffer:
+            return
+
+        try:
+            self._ensure_tables()
+            buffer = self._request_buffer
+            self._request_buffer = []
+
+            for metric in buffer:
+                self.db_tables['db'].execute(
+                    """INSERT INTO request_metrics
+                       (route, method, status_code, duration_ms, timestamp,
+                        user_did, request_size, response_size)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (metric.route, metric.method, metric.status_code,
+                     metric.duration_ms, metric.timestamp.isoformat(),
+                     metric.user_did, metric.request_size, metric.response_size)
+                )
+            self.db_tables['db'].execute("COMMIT")
+        except Exception as e:
+            logger.error(f"Error flushing request metrics: {e}")
+
+    def _flush_query_buffer(self):
+        """Flush query metrics to database."""
+        if not self.db_tables or not self._query_buffer:
+            return
+
+        try:
+            self._ensure_tables()
+            buffer = self._query_buffer
+            self._query_buffer = []
+
+            for metric in buffer:
+                self.db_tables['db'].execute(
+                    """INSERT INTO query_metrics
+                       (query_type, query_name, duration_ms, row_count, timestamp, caller)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (metric.query_type, metric.query_name, metric.duration_ms,
+                     metric.row_count, metric.timestamp.isoformat(), metric.caller)
+                )
+            self.db_tables['db'].execute("COMMIT")
+        except Exception as e:
+            logger.error(f"Error flushing query metrics: {e}")
+
+    def _flush_api_buffer(self):
+        """Flush API metrics to database."""
+        if not self.db_tables or not self._api_buffer:
+            return
+
+        try:
+            self._ensure_tables()
+            buffer = self._api_buffer
+            self._api_buffer = []
+
+            for metric in buffer:
+                self.db_tables['db'].execute(
+                    """INSERT INTO api_metrics
+                       (service, endpoint, duration_ms, status_code, success,
+                        error_message, timestamp)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    (metric.service, metric.endpoint, metric.duration_ms,
+                     metric.status_code, 1 if metric.success else 0,
+                     metric.error_message, metric.timestamp.isoformat())
+                )
+            self.db_tables['db'].execute("COMMIT")
+        except Exception as e:
+            logger.error(f"Error flushing API metrics: {e}")
+
+    def flush_all(self):
+        """Flush all buffers to database."""
+        with self._lock:
+            self._flush_request_buffer()
+            self._flush_query_buffer()
+            self._flush_api_buffer()
+
+    def get_request_stats(self, hours: int = 24) -> List[Dict[str, Any]]:
+        """Get request statistics for the given time period."""
+        if not self.db_tables:
+            return self._get_memory_request_stats()
+
+        try:
+            self._ensure_tables()
+            cutoff = (datetime.utcnow() - timedelta(hours=hours)).isoformat()
+            rows = self.db_tables['db'].execute(
+                """SELECT route, method,
+                          COUNT(*) as request_count,
+                          AVG(duration_ms) as avg_duration_ms,
+                          MAX(duration_ms) as max_duration_ms,
+                          MIN(duration_ms) as min_duration_ms,
+                          SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END) as error_count
+                   FROM request_metrics
+                   WHERE timestamp > ?
+                   GROUP BY route, method
+                   ORDER BY avg_duration_ms DESC
+                   LIMIT 50""",
+                (cutoff,)
+            ).fetchall()
+
+            return [
+                {
+                    'route': row[0],
+                    'method': row[1],
+                    'request_count': row[2],
+                    'avg_duration_ms': round(row[3], 1) if row[3] else 0,
+                    'max_duration_ms': round(row[4], 1) if row[4] else 0,
+                    'min_duration_ms': round(row[5], 1) if row[5] else 0,
+                    'error_count': row[6] or 0
+                }
+                for row in rows
+            ]
+        except Exception as e:
+            logger.error(f"Error getting request stats: {e}")
+            return self._get_memory_request_stats()
+
+    def _get_memory_request_stats(self) -> List[Dict[str, Any]]:
+        """Get request stats from in-memory aggregates."""
+        results = []
+        with self._lock:
+            for key, stats in self._route_stats.items():
+                parts = key.split(' ', 1)
+                method = parts[0] if len(parts) > 0 else 'GET'
+                route = parts[1] if len(parts) > 1 else key
+                results.append({
+                    'route': route,
+                    'method': method,
+                    'request_count': stats['count'],
+                    'avg_duration_ms': round(stats['total_ms'] / stats['count'], 1) if stats['count'] > 0 else 0,
+                    'max_duration_ms': round(stats['max_ms'], 1),
+                    'min_duration_ms': round(stats['min_ms'], 1) if stats['min_ms'] != float('inf') else 0,
+                    'error_count': 0
+                })
+        return sorted(results, key=lambda x: x['avg_duration_ms'], reverse=True)[:50]
+
+    def get_query_stats(self, hours: int = 24) -> List[Dict[str, Any]]:
+        """Get query statistics for the given time period."""
+        if not self.db_tables:
+            return self._get_memory_query_stats()
+
+        try:
+            self._ensure_tables()
+            cutoff = (datetime.utcnow() - timedelta(hours=hours)).isoformat()
+            rows = self.db_tables['db'].execute(
+                """SELECT query_name, query_type,
+                          COUNT(*) as query_count,
+                          AVG(duration_ms) as avg_duration_ms,
+                          MAX(duration_ms) as max_duration_ms,
+                          SUM(row_count) as total_rows
+                   FROM query_metrics
+                   WHERE timestamp > ?
+                   GROUP BY query_name, query_type
+                   ORDER BY avg_duration_ms DESC
+                   LIMIT 50""",
+                (cutoff,)
+            ).fetchall()
+
+            return [
+                {
+                    'query_name': row[0] or row[1],
+                    'query_type': row[1],
+                    'query_count': row[2],
+                    'avg_duration_ms': round(row[3], 1) if row[3] else 0,
+                    'max_duration_ms': round(row[4], 1) if row[4] else 0,
+                    'total_rows': row[5] or 0
+                }
+                for row in rows
+            ]
+        except Exception as e:
+            logger.error(f"Error getting query stats: {e}")
+            return self._get_memory_query_stats()
+
+    def _get_memory_query_stats(self) -> List[Dict[str, Any]]:
+        """Get query stats from in-memory aggregates."""
+        results = []
+        with self._lock:
+            for key, stats in self._query_stats.items():
+                results.append({
+                    'query_name': key,
+                    'query_type': 'select',
+                    'query_count': stats['count'],
+                    'avg_duration_ms': round(stats['total_ms'] / stats['count'], 1) if stats['count'] > 0 else 0,
+                    'max_duration_ms': round(stats['max_ms'], 1),
+                    'total_rows': 0
+                })
+        return sorted(results, key=lambda x: x['avg_duration_ms'], reverse=True)[:50]
+
+    def get_api_stats(self, hours: int = 24) -> List[Dict[str, Any]]:
+        """Get external API statistics for the given time period."""
+        if not self.db_tables:
+            return self._get_memory_api_stats()
+
+        try:
+            self._ensure_tables()
+            cutoff = (datetime.utcnow() - timedelta(hours=hours)).isoformat()
+            rows = self.db_tables['db'].execute(
+                """SELECT service, endpoint,
+                          COUNT(*) as call_count,
+                          AVG(duration_ms) as avg_duration_ms,
+                          MAX(duration_ms) as max_duration_ms,
+                          SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) as error_count
+                   FROM api_metrics
+                   WHERE timestamp > ?
+                   GROUP BY service, endpoint
+                   ORDER BY avg_duration_ms DESC
+                   LIMIT 50""",
+                (cutoff,)
+            ).fetchall()
+
+            return [
+                {
+                    'service': row[0],
+                    'endpoint': row[1],
+                    'call_count': row[2],
+                    'avg_duration_ms': round(row[3], 1) if row[3] else 0,
+                    'max_duration_ms': round(row[4], 1) if row[4] else 0,
+                    'error_count': row[5] or 0,
+                    'error_rate': round((row[5] or 0) / row[2] * 100, 1) if row[2] > 0 else 0
+                }
+                for row in rows
+            ]
+        except Exception as e:
+            logger.error(f"Error getting API stats: {e}")
+            return self._get_memory_api_stats()
+
+    def _get_memory_api_stats(self) -> List[Dict[str, Any]]:
+        """Get API stats from in-memory aggregates."""
+        results = []
+        with self._lock:
+            for key, stats in self._api_stats.items():
+                parts = key.split(':', 1)
+                service = parts[0]
+                endpoint = parts[1] if len(parts) > 1 else ''
+                results.append({
+                    'service': service,
+                    'endpoint': endpoint,
+                    'call_count': stats['count'],
+                    'avg_duration_ms': round(stats['total_ms'] / stats['count'], 1) if stats['count'] > 0 else 0,
+                    'max_duration_ms': round(stats['max_ms'], 1),
+                    'error_count': stats['errors'],
+                    'error_rate': round(stats['errors'] / stats['count'] * 100, 1) if stats['count'] > 0 else 0
+                })
+        return sorted(results, key=lambda x: x['avg_duration_ms'], reverse=True)[:50]
+
+    def get_slow_requests(self, threshold_ms: float = None, limit: int = 20) -> List[Dict[str, Any]]:
+        """Get recent slow requests."""
+        threshold = threshold_ms or self.SLOW_REQUEST_THRESHOLD_MS
+
+        if not self.db_tables:
+            return []
+
+        try:
+            self._ensure_tables()
+            rows = self.db_tables['db'].execute(
+                """SELECT route, method, status_code, duration_ms, timestamp, user_did
+                   FROM request_metrics
+                   WHERE duration_ms >= ?
+                   ORDER BY timestamp DESC
+                   LIMIT ?""",
+                (threshold, limit)
+            ).fetchall()
+
+            return [
+                {
+                    'route': row[0],
+                    'method': row[1],
+                    'status_code': row[2],
+                    'duration_ms': round(row[3], 1),
+                    'timestamp': row[4],
+                    'user_did': row[5]
+                }
+                for row in rows
+            ]
+        except Exception as e:
+            logger.error(f"Error getting slow requests: {e}")
+            return []
+
+    def get_overview_stats(self, hours: int = 24) -> Dict[str, Any]:
+        """Get an overview of performance stats for the dashboard."""
+        if not self.db_tables:
+            return self._get_memory_overview_stats()
+
+        try:
+            self._ensure_tables()
+            cutoff = (datetime.utcnow() - timedelta(hours=hours)).isoformat()
+
+            # Request stats
+            req_row = self.db_tables['db'].execute(
+                """SELECT COUNT(*) as total,
+                          AVG(duration_ms) as avg_ms,
+                          MAX(duration_ms) as max_ms,
+                          SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END) as errors,
+                          SUM(CASE WHEN duration_ms >= ? THEN 1 ELSE 0 END) as slow
+                   FROM request_metrics WHERE timestamp > ?""",
+                (self.SLOW_REQUEST_THRESHOLD_MS, cutoff)
+            ).fetchone()
+
+            # Query stats
+            query_row = self.db_tables['db'].execute(
+                """SELECT COUNT(*) as total,
+                          AVG(duration_ms) as avg_ms,
+                          MAX(duration_ms) as max_ms,
+                          SUM(CASE WHEN duration_ms >= ? THEN 1 ELSE 0 END) as slow
+                   FROM query_metrics WHERE timestamp > ?""",
+                (self.SLOW_QUERY_THRESHOLD_MS, cutoff)
+            ).fetchone()
+
+            # API stats
+            api_row = self.db_tables['db'].execute(
+                """SELECT COUNT(*) as total,
+                          AVG(duration_ms) as avg_ms,
+                          SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) as errors
+                   FROM api_metrics WHERE timestamp > ?""",
+                (cutoff,)
+            ).fetchone()
+
+            return {
+                'requests': {
+                    'total': req_row[0] or 0,
+                    'avg_ms': round(req_row[1], 1) if req_row[1] else 0,
+                    'max_ms': round(req_row[2], 1) if req_row[2] else 0,
+                    'errors': req_row[3] or 0,
+                    'slow': req_row[4] or 0
+                },
+                'queries': {
+                    'total': query_row[0] or 0,
+                    'avg_ms': round(query_row[1], 1) if query_row[1] else 0,
+                    'max_ms': round(query_row[2], 1) if query_row[2] else 0,
+                    'slow': query_row[3] or 0
+                },
+                'api_calls': {
+                    'total': api_row[0] or 0,
+                    'avg_ms': round(api_row[1], 1) if api_row[1] else 0,
+                    'errors': api_row[2] or 0
+                },
+                'period_hours': hours
+            }
+        except Exception as e:
+            logger.error(f"Error getting overview stats: {e}")
+            return self._get_memory_overview_stats()
+
+    def _get_memory_overview_stats(self) -> Dict[str, Any]:
+        """Get overview stats from in-memory data."""
+        with self._lock:
+            req_count = sum(s['count'] for s in self._route_stats.values())
+            req_total_ms = sum(s['total_ms'] for s in self._route_stats.values())
+
+            query_count = sum(s['count'] for s in self._query_stats.values())
+            query_total_ms = sum(s['total_ms'] for s in self._query_stats.values())
+
+            api_count = sum(s['count'] for s in self._api_stats.values())
+            api_total_ms = sum(s['total_ms'] for s in self._api_stats.values())
+            api_errors = sum(s['errors'] for s in self._api_stats.values())
+
+            return {
+                'requests': {
+                    'total': req_count,
+                    'avg_ms': round(req_total_ms / req_count, 1) if req_count > 0 else 0,
+                    'max_ms': max((s['max_ms'] for s in self._route_stats.values()), default=0),
+                    'errors': 0,
+                    'slow': 0
+                },
+                'queries': {
+                    'total': query_count,
+                    'avg_ms': round(query_total_ms / query_count, 1) if query_count > 0 else 0,
+                    'max_ms': max((s['max_ms'] for s in self._query_stats.values()), default=0),
+                    'slow': 0
+                },
+                'api_calls': {
+                    'total': api_count,
+                    'avg_ms': round(api_total_ms / api_count, 1) if api_count > 0 else 0,
+                    'errors': api_errors
+                },
+                'period_hours': 24
+            }
+
+    def cleanup_old_records(self, days: int = 7):
+        """Remove old performance records to prevent database bloat."""
+        if not self.db_tables:
+            return
+
+        try:
+            cutoff = (datetime.utcnow() - timedelta(days=days)).isoformat()
+
+            self.db_tables['db'].execute(
+                "DELETE FROM request_metrics WHERE timestamp < ?", (cutoff,)
+            )
+            self.db_tables['db'].execute(
+                "DELETE FROM query_metrics WHERE timestamp < ?", (cutoff,)
+            )
+            self.db_tables['db'].execute(
+                "DELETE FROM api_metrics WHERE timestamp < ?", (cutoff,)
+            )
+            self.db_tables['db'].execute("COMMIT")
+
+            logger.info(f"Cleaned up performance records older than {days} days")
+        except Exception as e:
+            logger.error(f"Error cleaning up performance records: {e}")
+
+
+# Context manager for timing operations
+@contextmanager
+def track_query(query_name: str, query_type: str = 'select'):
+    """Context manager to track database query timing."""
+    monitor = get_performance_monitor()
+    start = time.perf_counter()
+    row_count = None
+    try:
+        yield lambda count: setattr(track_query, '_row_count', count)
+        row_count = getattr(track_query, '_row_count', None)
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000
+        if monitor:
+            monitor.record_query(query_type, query_name, duration_ms, row_count)
+
+
+@contextmanager
+def track_api_call(service: str, endpoint: str):
+    """Context manager to track external API call timing."""
+    monitor = get_performance_monitor()
+    start = time.perf_counter()
+    success = True
+    error_msg = None
+    status_code = None
+    try:
+        yield lambda code: setattr(track_api_call, '_status_code', code)
+        status_code = getattr(track_api_call, '_status_code', None)
+    except Exception as e:
+        success = False
+        error_msg = str(e)
+        raise
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000
+        if monitor:
+            monitor.record_api_call(service, endpoint, duration_ms,
+                                     status_code, success, error_msg)
+
+
+def track_query_func(query_name: str, query_type: str = 'select'):
+    """Decorator to track function that performs a database query."""
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            monitor = get_performance_monitor()
+            start = time.perf_counter()
+            result = func(*args, **kwargs)
+            duration_ms = (time.perf_counter() - start) * 1000
+
+            # Try to get row count from result
+            row_count = None
+            if isinstance(result, (list, tuple)):
+                row_count = len(result)
+
+            if monitor:
+                monitor.record_query(query_type, query_name, duration_ms,
+                                      row_count, func.__name__)
+            return result
+        return wrapper
+    return decorator
+
+
+def track_api_func(service: str, endpoint: str):
+    """Decorator to track function that makes an external API call."""
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            monitor = get_performance_monitor()
+            start = time.perf_counter()
+            success = True
+            error_msg = None
+            try:
+                result = func(*args, **kwargs)
+                return result
+            except Exception as e:
+                success = False
+                error_msg = str(e)
+                raise
+            finally:
+                duration_ms = (time.perf_counter() - start) * 1000
+                if monitor:
+                    monitor.record_api_call(service, endpoint, duration_ms,
+                                             None, success, error_msg)
+        return wrapper
+    return decorator
+
+
+def init_performance_monitoring(db_tables=None) -> PerformanceMonitor:
+    """Initialize the global performance monitor."""
+    global _performance_monitor
+    _performance_monitor = PerformanceMonitor(db_tables)
+    return _performance_monitor
+
+
+def get_performance_monitor() -> Optional[PerformanceMonitor]:
+    """Get the global performance monitor instance."""
+    return _performance_monitor

--- a/tests/integration/test_performance_integration.py
+++ b/tests/integration/test_performance_integration.py
@@ -1,0 +1,360 @@
+"""
+Integration tests for performance monitoring.
+
+These tests verify the integration between the performance monitor,
+middleware, and admin routes.
+"""
+
+import pytest
+import time
+from unittest.mock import MagicMock, patch, AsyncMock
+from datetime import datetime
+
+
+# ============================================================================
+# Test Performance Monitor with Database
+# ============================================================================
+
+class TestPerformanceMonitorWithDB:
+    """Tests for PerformanceMonitor with actual database operations."""
+
+    @pytest.fixture
+    def monitor_with_db(self, db_tables):
+        """Create a performance monitor with database tables."""
+        from performance_monitor import PerformanceMonitor
+
+        # Create performance tables
+        db_tables['db'].execute("""
+            CREATE TABLE IF NOT EXISTS request_metrics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                route TEXT NOT NULL,
+                method TEXT NOT NULL DEFAULT 'GET',
+                status_code INTEGER,
+                duration_ms REAL NOT NULL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                user_did TEXT,
+                request_size INTEGER,
+                response_size INTEGER
+            )
+        """)
+        db_tables['db'].execute("""
+            CREATE TABLE IF NOT EXISTS query_metrics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                query_type TEXT NOT NULL,
+                query_name TEXT,
+                duration_ms REAL NOT NULL,
+                row_count INTEGER,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                caller TEXT
+            )
+        """)
+        db_tables['db'].execute("""
+            CREATE TABLE IF NOT EXISTS api_metrics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                service TEXT NOT NULL,
+                endpoint TEXT NOT NULL,
+                duration_ms REAL NOT NULL,
+                status_code INTEGER,
+                success INTEGER NOT NULL DEFAULT 1,
+                error_message TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        monitor = PerformanceMonitor(db_tables=db_tables)
+        monitor._buffer_size = 2  # Low threshold for testing
+
+        return monitor, db_tables
+
+    @pytest.mark.integration
+    def test_request_metrics_persisted(self, monitor_with_db):
+        """Request metrics are persisted to database."""
+        monitor, db_tables = monitor_with_db
+
+        # Record enough requests to trigger flush
+        monitor.record_request("/test1", "GET", 200, 100)
+        monitor.record_request("/test2", "GET", 200, 150)
+        monitor.record_request("/test3", "GET", 200, 200)
+
+        # Force flush
+        monitor.flush_all()
+
+        # Check database
+        rows = db_tables['db'].execute(
+            "SELECT route, duration_ms FROM request_metrics"
+        ).fetchall()
+
+        assert len(rows) >= 1
+
+    @pytest.mark.integration
+    def test_query_metrics_persisted(self, monitor_with_db):
+        """Query metrics are persisted to database."""
+        monitor, db_tables = monitor_with_db
+
+        monitor.record_query("select", "test_query", 50, row_count=10)
+        monitor.record_query("select", "test_query", 75, row_count=20)
+        monitor.record_query("select", "test_query", 100, row_count=30)
+
+        monitor.flush_all()
+
+        rows = db_tables['db'].execute(
+            "SELECT query_name, duration_ms FROM query_metrics"
+        ).fetchall()
+
+        assert len(rows) >= 1
+
+    @pytest.mark.integration
+    def test_api_metrics_persisted(self, monitor_with_db):
+        """API metrics are persisted to database."""
+        monitor, db_tables = monitor_with_db
+
+        monitor.record_api_call("google_books", "search", 500, success=True)
+        monitor.record_api_call("google_books", "search", 600, success=False, error_message="timeout")
+        monitor.record_api_call("open_library", "search", 800, success=True)
+
+        monitor.flush_all()
+
+        rows = db_tables['db'].execute(
+            "SELECT service, endpoint, success FROM api_metrics"
+        ).fetchall()
+
+        assert len(rows) >= 1
+
+    @pytest.mark.integration
+    def test_get_request_stats_from_db(self, monitor_with_db):
+        """Request stats can be retrieved from database."""
+        monitor, db_tables = monitor_with_db
+
+        # Insert test data
+        monitor.record_request("/api/test", "GET", 200, 100)
+        monitor.record_request("/api/test", "GET", 200, 200)
+        monitor.record_request("/api/other", "POST", 201, 50)
+        monitor.flush_all()
+
+        # Get stats
+        stats = monitor.get_request_stats(hours=24)
+
+        # Should have aggregated results
+        assert isinstance(stats, list)
+
+    @pytest.mark.integration
+    def test_get_slow_requests_from_db(self, monitor_with_db):
+        """Slow requests can be retrieved from database."""
+        monitor, db_tables = monitor_with_db
+
+        # Insert test data including slow requests
+        monitor.record_request("/fast", "GET", 200, 50)
+        monitor.record_request("/slow", "GET", 200, 1500)
+        monitor.record_request("/very_slow", "GET", 200, 3000)
+        monitor.flush_all()
+
+        # Get slow requests
+        slow = monitor.get_slow_requests(threshold_ms=1000, limit=10)
+
+        # Should return slow requests (may depend on buffer behavior)
+        assert isinstance(slow, list)
+
+    @pytest.mark.integration
+    def test_cleanup_old_records(self, monitor_with_db):
+        """Old records can be cleaned up."""
+        monitor, db_tables = monitor_with_db
+
+        # Insert test data
+        monitor.record_request("/test", "GET", 200, 100)
+        monitor.flush_all()
+
+        # Cleanup (with 0 days should remove everything)
+        monitor.cleanup_old_records(days=0)
+
+        # Verify cleanup
+        rows = db_tables['db'].execute(
+            "SELECT COUNT(*) FROM request_metrics"
+        ).fetchone()
+
+        # Records should be cleaned (timestamp is current, so 0 days removes all)
+        assert rows[0] == 0
+
+
+# ============================================================================
+# Test Decorated Model Functions
+# ============================================================================
+
+class TestDecoratedModelFunctions:
+    """Tests for model functions with performance tracking decorators."""
+
+    @pytest.mark.integration
+    def test_get_public_shelves_with_stats_tracked(self, db_with_books):
+        """get_public_shelves_with_stats is tracked."""
+        from performance_monitor import init_performance_monitoring, get_performance_monitor
+        from models import get_public_shelves_with_stats
+
+        db_tables, owner, shelf, books = db_with_books
+
+        # Initialize monitor
+        monitor = init_performance_monitoring()
+
+        # Call the decorated function
+        result = get_public_shelves_with_stats(db_tables, limit=10)
+
+        # Check that it was tracked
+        assert 'get_public_shelves_with_stats' in monitor._query_stats
+        assert monitor._query_stats['get_public_shelves_with_stats']['count'] == 1
+
+    @pytest.mark.integration
+    def test_get_user_shelves_tracked(self, db_with_shelf):
+        """get_user_shelves is tracked."""
+        from performance_monitor import init_performance_monitoring, get_performance_monitor
+        from models import get_user_shelves
+
+        db_tables, owner, shelf = db_with_shelf
+
+        # Initialize monitor
+        monitor = init_performance_monitoring()
+
+        # Call the decorated function
+        result = get_user_shelves(owner.did, db_tables, limit=10)
+
+        # Check that it was tracked
+        assert 'get_user_shelves' in monitor._query_stats
+
+    @pytest.mark.integration
+    def test_get_mixed_public_shelves_tracked(self, db_with_books):
+        """get_mixed_public_shelves is tracked."""
+        from performance_monitor import init_performance_monitoring, get_performance_monitor
+        from models import get_mixed_public_shelves
+
+        db_tables, owner, shelf, books = db_with_books
+
+        # Initialize monitor
+        monitor = init_performance_monitoring()
+
+        # Call the decorated function
+        result = get_mixed_public_shelves(db_tables, limit=10)
+
+        # Check that it was tracked
+        assert 'get_mixed_public_shelves' in monitor._query_stats
+
+
+# ============================================================================
+# Test Book API Client Tracking
+# ============================================================================
+
+class TestBookAPIClientTracking:
+    """Tests for book API client with performance tracking."""
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_search_books_tracks_google_success(self):
+        """Successful Google Books search is tracked."""
+        from performance_monitor import init_performance_monitoring, get_performance_monitor
+        from bibliome.clients.books import BookAPIClient
+
+        monitor = init_performance_monitoring()
+
+        # Mock the HTTP client
+        with patch('httpx.AsyncClient') as MockClient:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                'items': [{
+                    'volumeInfo': {
+                        'title': 'Test Book',
+                        'authors': ['Test Author'],
+                        'industryIdentifiers': [{'type': 'ISBN_13', 'identifier': '9781234567890'}]
+                    }
+                }]
+            }
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+
+            MockClient.return_value = mock_client_instance
+
+            client = BookAPIClient()
+
+            # Mock rate limiter
+            with patch.object(client.rate_limiter, 'execute_with_backoff', new_callable=AsyncMock) as mock_rate:
+                mock_rate.return_value = mock_response
+
+                result = await client.search_books("test query")
+
+            # Check tracking
+            assert 'google_books:search' in monitor._api_stats
+
+
+# ============================================================================
+# Test Migration
+# ============================================================================
+
+class TestPerformanceMigration:
+    """Tests for the performance monitoring database migration."""
+
+    @pytest.mark.integration
+    def test_migration_creates_tables(self, db_tables):
+        """Migration creates required tables."""
+        import os
+
+        # Read and execute migration
+        migration_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            'migrations',
+            '0011-add-performance-monitoring.sql'
+        )
+
+        with open(migration_path, 'r') as f:
+            migration_sql = f.read()
+
+        # Execute migration (split by semicolon for multiple statements)
+        for statement in migration_sql.split(';'):
+            statement = statement.strip()
+            if statement and not statement.startswith('--'):
+                try:
+                    db_tables['db'].execute(statement)
+                except Exception:
+                    pass  # Ignore errors for CREATE IF NOT EXISTS
+
+        # Verify tables exist
+        tables = db_tables['db'].execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        table_names = [t[0] for t in tables]
+
+        assert 'request_metrics' in table_names
+        assert 'query_metrics' in table_names
+        assert 'api_metrics' in table_names
+
+    @pytest.mark.integration
+    def test_migration_creates_indexes(self, db_tables):
+        """Migration creates performance indexes."""
+        import os
+
+        # Execute migration
+        migration_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            'migrations',
+            '0011-add-performance-monitoring.sql'
+        )
+
+        with open(migration_path, 'r') as f:
+            migration_sql = f.read()
+
+        for statement in migration_sql.split(';'):
+            statement = statement.strip()
+            if statement and not statement.startswith('--'):
+                try:
+                    db_tables['db'].execute(statement)
+                except Exception:
+                    pass
+
+        # Verify indexes exist
+        indexes = db_tables['db'].execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()
+        index_names = [i[0] for i in indexes]
+
+        assert 'idx_request_metrics_route' in index_names
+        assert 'idx_query_metrics_name' in index_names
+        assert 'idx_api_metrics_service' in index_names

--- a/tests/unit/test_performance_components.py
+++ b/tests/unit/test_performance_components.py
@@ -1,0 +1,421 @@
+"""
+Unit tests for performance monitoring admin components.
+
+These tests verify the UI components render correctly with various data states.
+
+Note: These tests require the full FastHTML environment. If imports fail due to
+missing dependencies, tests will be skipped.
+"""
+
+import pytest
+import sys
+import os
+
+# Add project root to path for direct imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+# Skip all tests if fasthtml dependencies are not available
+try:
+    from fasthtml.common import Div, H1, P, Table
+    HAS_FASTHTML = True
+except ImportError:
+    HAS_FASTHTML = False
+
+pytestmark = pytest.mark.skipif(not HAS_FASTHTML, reason="FastHTML not available")
+
+
+# ============================================================================
+# Test PerformanceDashboard Component
+# ============================================================================
+
+@pytest.mark.unit
+class TestPerformanceDashboard:
+    """Tests for the main PerformanceDashboard component."""
+
+    def test_dashboard_renders_with_empty_stats(self):
+        """Dashboard renders correctly with empty statistics."""
+        from bibliome.components.admin import PerformanceDashboard
+
+        stats = {
+            'requests': {'total': 0, 'avg_ms': 0, 'max_ms': 0, 'errors': 0, 'slow': 0},
+            'queries': {'total': 0, 'avg_ms': 0, 'max_ms': 0, 'slow': 0},
+            'api_calls': {'total': 0, 'avg_ms': 0, 'errors': 0},
+            'period_hours': 24
+        }
+
+        result = PerformanceDashboard(stats)
+        assert result is not None
+
+    def test_dashboard_renders_with_data(self):
+        """Dashboard renders correctly with actual statistics."""
+        from bibliome.components.admin import PerformanceDashboard
+
+        stats = {
+            'requests': {'total': 1500, 'avg_ms': 150.5, 'max_ms': 5000, 'errors': 10, 'slow': 25},
+            'queries': {'total': 5000, 'avg_ms': 25.3, 'max_ms': 500, 'slow': 100},
+            'api_calls': {'total': 200, 'avg_ms': 800, 'errors': 5},
+            'period_hours': 24
+        }
+
+        result = PerformanceDashboard(stats)
+        assert result is not None
+
+    def test_dashboard_handles_missing_keys(self):
+        """Dashboard handles missing stat keys gracefully."""
+        from bibliome.components.admin import PerformanceDashboard
+
+        stats = {
+            'requests': {},
+            'queries': {},
+            'api_calls': {},
+            'period_hours': 24
+        }
+
+        result = PerformanceDashboard(stats)
+        assert result is not None
+
+
+# ============================================================================
+# Test PerformanceOverviewCard Component
+# ============================================================================
+
+@pytest.mark.unit
+class TestPerformanceOverviewCard:
+    """Tests for the overview card component."""
+
+    def test_card_renders_success_status(self):
+        """Card renders with success status styling."""
+        from bibliome.components.admin import PerformanceOverviewCard
+
+        result = PerformanceOverviewCard(
+            title="Requests",
+            count=1000,
+            detail1="Avg: 100ms",
+            detail2="Slow: 0",
+            icon="fa-globe",
+            status="success"
+        )
+        assert result is not None
+
+    def test_card_renders_warning_status(self):
+        """Card renders with warning status styling."""
+        from bibliome.components.admin import PerformanceOverviewCard
+
+        result = PerformanceOverviewCard(
+            title="Queries",
+            count=500,
+            detail1="Avg: 75ms",
+            detail2="Slow: 10",
+            icon="fa-database",
+            status="warning"
+        )
+        assert result is not None
+
+    def test_card_renders_danger_status(self):
+        """Card renders with danger status styling."""
+        from bibliome.components.admin import PerformanceOverviewCard
+
+        result = PerformanceOverviewCard(
+            title="API Calls",
+            count=100,
+            detail1="Avg: 2000ms",
+            detail2="Errors: 50",
+            icon="fa-cloud",
+            status="danger"
+        )
+        assert result is not None
+
+    def test_card_formats_large_numbers(self):
+        """Card formats large numbers with commas."""
+        from bibliome.components.admin import PerformanceOverviewCard
+
+        result = PerformanceOverviewCard(
+            title="Requests",
+            count=1000000,
+            detail1="Avg: 50ms",
+            detail2="Slow: 0",
+            icon="fa-globe",
+            status="success"
+        )
+        assert result is not None
+
+
+# ============================================================================
+# Test PerformanceRouteTable Component
+# ============================================================================
+
+@pytest.mark.unit
+class TestPerformanceRouteTable:
+    """Tests for the route performance table component."""
+
+    def test_table_renders_empty_state(self):
+        """Table shows empty message when no routes."""
+        from bibliome.components.admin import PerformanceRouteTable
+
+        result = PerformanceRouteTable([])
+        assert result is not None
+
+    def test_table_renders_with_routes(self):
+        """Table renders route data correctly."""
+        from bibliome.components.admin import PerformanceRouteTable
+
+        routes = [
+            {
+                'route': '/api/shelves',
+                'method': 'GET',
+                'request_count': 500,
+                'avg_duration_ms': 150,
+                'max_duration_ms': 2000,
+                'error_count': 5
+            },
+            {
+                'route': '/api/books',
+                'method': 'POST',
+                'request_count': 100,
+                'avg_duration_ms': 50,
+                'max_duration_ms': 500,
+                'error_count': 0
+            }
+        ]
+
+        result = PerformanceRouteTable(routes)
+        assert result is not None
+
+    def test_table_limits_to_15_routes(self):
+        """Table only shows first 15 routes."""
+        from bibliome.components.admin import PerformanceRouteTable
+
+        routes = [
+            {
+                'route': f'/api/route{i}',
+                'method': 'GET',
+                'request_count': i * 10,
+                'avg_duration_ms': i * 5,
+                'max_duration_ms': i * 10,
+                'error_count': 0
+            }
+            for i in range(20)
+        ]
+
+        result = PerformanceRouteTable(routes)
+        assert result is not None
+
+    def test_table_handles_slow_routes(self):
+        """Table applies correct styling for slow routes."""
+        from bibliome.components.admin import PerformanceRouteTable
+
+        routes = [
+            {
+                'route': '/slow/route',
+                'method': 'GET',
+                'request_count': 10,
+                'avg_duration_ms': 1500,
+                'max_duration_ms': 3000,
+                'error_count': 0
+            }
+        ]
+
+        result = PerformanceRouteTable(routes)
+        assert result is not None
+
+
+# ============================================================================
+# Test PerformanceQueryTable Component
+# ============================================================================
+
+@pytest.mark.unit
+class TestPerformanceQueryTable:
+    """Tests for the query performance table component."""
+
+    def test_table_renders_empty_state(self):
+        """Table shows empty message when no queries."""
+        from bibliome.components.admin import PerformanceQueryTable
+
+        result = PerformanceQueryTable([])
+        assert result is not None
+
+    def test_table_renders_with_queries(self):
+        """Table renders query data correctly."""
+        from bibliome.components.admin import PerformanceQueryTable
+
+        queries = [
+            {
+                'query_name': 'get_public_shelves_with_stats',
+                'query_type': 'select',
+                'query_count': 1000,
+                'avg_duration_ms': 45.5,
+                'max_duration_ms': 200,
+                'total_rows': 50000
+            },
+            {
+                'query_name': 'get_network_activity',
+                'query_type': 'select',
+                'query_count': 500,
+                'avg_duration_ms': 75.2,
+                'max_duration_ms': 300,
+                'total_rows': 10000
+            }
+        ]
+
+        result = PerformanceQueryTable(queries)
+        assert result is not None
+
+    def test_table_handles_slow_queries(self):
+        """Table applies correct styling for slow queries."""
+        from bibliome.components.admin import PerformanceQueryTable
+
+        queries = [
+            {
+                'query_name': 'very_slow_query',
+                'query_type': 'select',
+                'query_count': 10,
+                'avg_duration_ms': 150,
+                'max_duration_ms': 500,
+                'total_rows': 1000
+            }
+        ]
+
+        result = PerformanceQueryTable(queries)
+        assert result is not None
+
+
+# ============================================================================
+# Test PerformanceApiTable Component
+# ============================================================================
+
+@pytest.mark.unit
+class TestPerformanceApiTable:
+    """Tests for the API performance table component."""
+
+    def test_table_renders_empty_state(self):
+        """Table shows empty message when no API calls."""
+        from bibliome.components.admin import PerformanceApiTable
+
+        result = PerformanceApiTable([])
+        assert result is not None
+
+    def test_table_renders_with_apis(self):
+        """Table renders API data correctly."""
+        from bibliome.components.admin import PerformanceApiTable
+
+        apis = [
+            {
+                'service': 'google_books',
+                'endpoint': 'search',
+                'call_count': 200,
+                'avg_duration_ms': 800,
+                'max_duration_ms': 2000,
+                'error_count': 5,
+                'error_rate': 2.5
+            },
+            {
+                'service': 'open_library',
+                'endpoint': 'search',
+                'call_count': 50,
+                'avg_duration_ms': 1200,
+                'max_duration_ms': 3000,
+                'error_count': 10,
+                'error_rate': 20.0
+            }
+        ]
+
+        result = PerformanceApiTable(apis)
+        assert result is not None
+
+    def test_table_highlights_high_error_rate(self):
+        """Table highlights APIs with high error rates."""
+        from bibliome.components.admin import PerformanceApiTable
+
+        apis = [
+            {
+                'service': 'failing_api',
+                'endpoint': 'broken',
+                'call_count': 100,
+                'avg_duration_ms': 500,
+                'max_duration_ms': 1000,
+                'error_count': 50,
+                'error_rate': 50.0
+            }
+        ]
+
+        result = PerformanceApiTable(apis)
+        assert result is not None
+
+
+# ============================================================================
+# Test SlowRequestsList Component
+# ============================================================================
+
+@pytest.mark.unit
+class TestSlowRequestsList:
+    """Tests for the slow requests list component."""
+
+    def test_list_renders_empty_state(self):
+        """List shows success message when no slow requests."""
+        from bibliome.components.admin import SlowRequestsList
+
+        result = SlowRequestsList([])
+        assert result is not None
+
+    def test_list_renders_with_requests(self):
+        """List renders slow request data correctly."""
+        from bibliome.components.admin import SlowRequestsList
+
+        requests = [
+            {
+                'route': '/api/slow-route',
+                'method': 'GET',
+                'status_code': 200,
+                'duration_ms': 2500,
+                'timestamp': '2026-01-28T10:30:00',
+                'user_did': 'did:plc:user123'
+            },
+            {
+                'route': '/api/another-slow',
+                'method': 'POST',
+                'status_code': 500,
+                'duration_ms': 5000,
+                'timestamp': '2026-01-28T10:31:00',
+                'user_did': None
+            }
+        ]
+
+        result = SlowRequestsList(requests)
+        assert result is not None
+
+    def test_list_limits_to_10_requests(self):
+        """List only shows first 10 requests."""
+        from bibliome.components.admin import SlowRequestsList
+
+        requests = [
+            {
+                'route': f'/api/route{i}',
+                'method': 'GET',
+                'status_code': 200,
+                'duration_ms': 1000 + i * 100,
+                'timestamp': f'2026-01-28T10:{30+i}:00',
+                'user_did': None
+            }
+            for i in range(15)
+        ]
+
+        result = SlowRequestsList(requests)
+        assert result is not None
+
+    def test_list_handles_missing_fields(self):
+        """List handles requests with missing optional fields."""
+        from bibliome.components.admin import SlowRequestsList
+
+        requests = [
+            {
+                'route': '/api/test',
+                'method': 'GET',
+                'status_code': None,
+                'duration_ms': 2000,
+                'timestamp': '',
+                'user_did': None
+            }
+        ]
+
+        result = SlowRequestsList(requests)
+        assert result is not None

--- a/tests/unit/test_performance_monitor.py
+++ b/tests/unit/test_performance_monitor.py
@@ -1,0 +1,689 @@
+"""
+Unit tests for the performance monitoring module.
+
+These tests verify the PerformanceMonitor class, tracking decorators,
+context managers, and metric recording functionality.
+"""
+
+import pytest
+import time
+import threading
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+
+# ============================================================================
+# Test PerformanceMonitor Class
+# ============================================================================
+
+class TestPerformanceMonitorInit:
+    """Tests for PerformanceMonitor initialization."""
+
+    @pytest.mark.unit
+    def test_init_without_db(self):
+        """PerformanceMonitor can be initialized without database."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        assert monitor.db_tables is None
+        assert monitor._enabled is True
+        assert len(monitor._request_buffer) == 0
+
+    @pytest.mark.unit
+    def test_init_with_db_tables(self):
+        """PerformanceMonitor accepts db_tables on init."""
+        from performance_monitor import PerformanceMonitor
+
+        mock_db = MagicMock()
+        monitor = PerformanceMonitor(db_tables=mock_db)
+
+        assert monitor.db_tables == mock_db
+
+    @pytest.mark.unit
+    def test_default_thresholds(self):
+        """PerformanceMonitor has sensible default thresholds."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        assert monitor.SLOW_REQUEST_THRESHOLD_MS == 1000
+        assert monitor.SLOW_QUERY_THRESHOLD_MS == 100
+        assert monitor.SLOW_API_THRESHOLD_MS == 2000
+
+
+class TestRecordRequest:
+    """Tests for recording request metrics."""
+
+    @pytest.mark.unit
+    def test_record_request_basic(self):
+        """Basic request recording works correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        monitor.record_request(
+            route="/api/test",
+            method="GET",
+            status_code=200,
+            duration_ms=50.5
+        )
+
+        # Check in-memory stats
+        key = "GET /api/test"
+        assert key in monitor._route_stats
+        assert monitor._route_stats[key]['count'] == 1
+        assert monitor._route_stats[key]['total_ms'] == 50.5
+
+    @pytest.mark.unit
+    def test_record_request_aggregates_stats(self):
+        """Multiple requests aggregate correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        # Record multiple requests
+        monitor.record_request("/api/test", "GET", 200, 100)
+        monitor.record_request("/api/test", "GET", 200, 200)
+        monitor.record_request("/api/test", "GET", 500, 300)
+
+        key = "GET /api/test"
+        assert monitor._route_stats[key]['count'] == 3
+        assert monitor._route_stats[key]['total_ms'] == 600
+        assert monitor._route_stats[key]['max_ms'] == 300
+        assert monitor._route_stats[key]['min_ms'] == 100
+
+    @pytest.mark.unit
+    def test_record_request_with_user_did(self):
+        """Request recording accepts user_did parameter."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        monitor.record_request(
+            route="/api/test",
+            method="POST",
+            status_code=201,
+            duration_ms=100,
+            user_did="did:plc:testuser123"
+        )
+
+        # Should be in buffer
+        assert len(monitor._request_buffer) == 1
+        assert monitor._request_buffer[0].user_did == "did:plc:testuser123"
+
+    @pytest.mark.unit
+    def test_record_request_disabled(self):
+        """Request recording does nothing when disabled."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        monitor._enabled = False
+
+        monitor.record_request("/api/test", "GET", 200, 100)
+
+        assert len(monitor._request_buffer) == 0
+        assert len(monitor._route_stats) == 0
+
+    @pytest.mark.unit
+    def test_slow_request_logging(self, caplog):
+        """Slow requests are logged as warnings."""
+        from performance_monitor import PerformanceMonitor
+        import logging
+
+        monitor = PerformanceMonitor()
+
+        with caplog.at_level(logging.WARNING):
+            monitor.record_request("/slow/route", "GET", 200, 1500)
+
+        assert "Slow request" in caplog.text
+        assert "/slow/route" in caplog.text
+
+
+class TestRecordQuery:
+    """Tests for recording database query metrics."""
+
+    @pytest.mark.unit
+    def test_record_query_basic(self):
+        """Basic query recording works correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        monitor.record_query(
+            query_type="select",
+            query_name="get_user",
+            duration_ms=15.5
+        )
+
+        assert "get_user" in monitor._query_stats
+        assert monitor._query_stats["get_user"]['count'] == 1
+
+    @pytest.mark.unit
+    def test_record_query_with_row_count(self):
+        """Query recording accepts row_count parameter."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        monitor.record_query(
+            query_type="select",
+            query_name="get_users",
+            duration_ms=25,
+            row_count=100
+        )
+
+        assert len(monitor._query_buffer) == 1
+        assert monitor._query_buffer[0].row_count == 100
+
+    @pytest.mark.unit
+    def test_record_query_with_caller(self):
+        """Query recording accepts caller parameter."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        monitor.record_query(
+            query_type="select",
+            query_name="get_shelves",
+            duration_ms=30,
+            caller="get_public_shelves_with_stats"
+        )
+
+        assert monitor._query_buffer[0].caller == "get_public_shelves_with_stats"
+
+    @pytest.mark.unit
+    def test_slow_query_logging(self, caplog):
+        """Slow queries are logged as warnings."""
+        from performance_monitor import PerformanceMonitor
+        import logging
+
+        monitor = PerformanceMonitor()
+
+        with caplog.at_level(logging.WARNING):
+            monitor.record_query("select", "slow_query", 150)
+
+        assert "Slow query" in caplog.text
+        assert "slow_query" in caplog.text
+
+
+class TestRecordApiCall:
+    """Tests for recording external API call metrics."""
+
+    @pytest.mark.unit
+    def test_record_api_call_basic(self):
+        """Basic API call recording works correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        monitor.record_api_call(
+            service="google_books",
+            endpoint="search",
+            duration_ms=500
+        )
+
+        key = "google_books:search"
+        assert key in monitor._api_stats
+        assert monitor._api_stats[key]['count'] == 1
+
+    @pytest.mark.unit
+    def test_record_api_call_with_error(self):
+        """API call recording tracks errors correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        # Record successful call
+        monitor.record_api_call("test_api", "endpoint", 100, success=True)
+        # Record failed call
+        monitor.record_api_call(
+            "test_api", "endpoint", 200,
+            success=False, error_message="Connection timeout"
+        )
+
+        key = "test_api:endpoint"
+        assert monitor._api_stats[key]['count'] == 2
+        assert monitor._api_stats[key]['errors'] == 1
+
+    @pytest.mark.unit
+    def test_slow_api_call_logging(self, caplog):
+        """Slow API calls are logged as warnings."""
+        from performance_monitor import PerformanceMonitor
+        import logging
+
+        monitor = PerformanceMonitor()
+
+        with caplog.at_level(logging.WARNING):
+            monitor.record_api_call("external_api", "slow_endpoint", 2500)
+
+        assert "Slow API call" in caplog.text
+
+
+class TestGetStats:
+    """Tests for retrieving statistics."""
+
+    @pytest.mark.unit
+    def test_get_memory_request_stats(self):
+        """In-memory request stats are retrieved correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        # Add some data
+        monitor.record_request("/api/a", "GET", 200, 100)
+        monitor.record_request("/api/a", "GET", 200, 200)
+        monitor.record_request("/api/b", "POST", 201, 50)
+
+        stats = monitor._get_memory_request_stats()
+
+        assert len(stats) == 2
+        # Should be sorted by avg duration descending
+        assert stats[0]['avg_duration_ms'] >= stats[1]['avg_duration_ms']
+
+    @pytest.mark.unit
+    def test_get_memory_query_stats(self):
+        """In-memory query stats are retrieved correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        monitor.record_query("select", "query_a", 50)
+        monitor.record_query("select", "query_b", 100)
+        monitor.record_query("select", "query_b", 150)
+
+        stats = monitor._get_memory_query_stats()
+
+        assert len(stats) == 2
+        # query_b should have higher average
+        query_b_stat = next(s for s in stats if s['query_name'] == 'query_b')
+        assert query_b_stat['avg_duration_ms'] == 125.0
+
+    @pytest.mark.unit
+    def test_get_memory_api_stats(self):
+        """In-memory API stats are retrieved correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        monitor.record_api_call("service_a", "endpoint", 100, success=True)
+        monitor.record_api_call("service_a", "endpoint", 200, success=False)
+
+        stats = monitor._get_memory_api_stats()
+
+        assert len(stats) == 1
+        assert stats[0]['call_count'] == 2
+        assert stats[0]['error_count'] == 1
+        assert stats[0]['error_rate'] == 50.0
+
+    @pytest.mark.unit
+    def test_get_overview_stats_memory(self):
+        """Overview stats from memory work correctly."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        monitor.record_request("/test", "GET", 200, 100)
+        monitor.record_query("select", "test_query", 50)
+        monitor.record_api_call("test_api", "endpoint", 200, success=True)
+        monitor.record_api_call("test_api", "endpoint", 300, success=False)
+
+        overview = monitor.get_overview_stats()
+
+        assert overview['requests']['total'] == 1
+        assert overview['queries']['total'] == 1
+        assert overview['api_calls']['total'] == 2
+        assert overview['api_calls']['errors'] == 1
+
+
+class TestBufferFlushing:
+    """Tests for buffer management and flushing."""
+
+    @pytest.mark.unit
+    def test_buffer_size_threshold(self):
+        """Buffer flushes when threshold is reached."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        monitor._buffer_size = 5  # Low threshold for testing
+
+        # Should not flush yet
+        for i in range(4):
+            monitor.record_request(f"/api/{i}", "GET", 200, 10)
+
+        assert len(monitor._request_buffer) == 4
+
+        # This should trigger flush (but without db, buffer just clears in lock)
+        monitor.record_request("/api/5", "GET", 200, 10)
+
+        # Without db_tables, flush doesn't persist but buffer is cleared
+        # The 5th item is added after the flush
+        assert len(monitor._request_buffer) <= 5
+
+    @pytest.mark.unit
+    def test_flush_all_attempts_flush(self):
+        """flush_all attempts to flush all buffers."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+
+        monitor.record_request("/test", "GET", 200, 100)
+        monitor.record_query("select", "test", 50)
+        monitor.record_api_call("api", "endpoint", 200)
+
+        # Without db, buffers won't clear but flush should not error
+        monitor.flush_all()
+
+        # Without db_tables, data stays in buffer (no persistence target)
+        # The important thing is it doesn't error
+        assert True
+
+
+class TestThreadSafety:
+    """Tests for thread safety of the monitor."""
+
+    @pytest.mark.unit
+    def test_concurrent_request_recording(self):
+        """Concurrent request recording doesn't lose data."""
+        from performance_monitor import PerformanceMonitor
+
+        monitor = PerformanceMonitor()
+        num_threads = 10
+        requests_per_thread = 100
+
+        def record_requests(thread_id):
+            for i in range(requests_per_thread):
+                monitor.record_request(
+                    f"/thread/{thread_id}",
+                    "GET",
+                    200,
+                    float(i)
+                )
+
+        threads = [
+            threading.Thread(target=record_requests, args=(i,))
+            for i in range(num_threads)
+        ]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Check total count across all route stats
+        total_count = sum(s['count'] for s in monitor._route_stats.values())
+        assert total_count == num_threads * requests_per_thread
+
+
+# ============================================================================
+# Test Tracking Decorators
+# ============================================================================
+
+class TestTrackQueryFunc:
+    """Tests for the track_query_func decorator."""
+
+    @pytest.mark.unit
+    def test_decorator_tracks_function(self):
+        """Decorator tracks function execution time."""
+        from performance_monitor import track_query_func, init_performance_monitoring, get_performance_monitor
+
+        monitor = init_performance_monitoring()
+
+        @track_query_func('test_function', 'select')
+        def test_function():
+            time.sleep(0.01)  # 10ms
+            return [1, 2, 3]
+
+        result = test_function()
+
+        assert result == [1, 2, 3]
+        assert 'test_function' in monitor._query_stats
+        assert monitor._query_stats['test_function']['count'] == 1
+
+    @pytest.mark.unit
+    def test_decorator_counts_list_results(self):
+        """Decorator counts rows when result is a list."""
+        from performance_monitor import track_query_func, init_performance_monitoring
+
+        monitor = init_performance_monitoring()
+
+        @track_query_func('list_function', 'select')
+        def list_function():
+            return ['a', 'b', 'c', 'd', 'e']
+
+        result = list_function()
+
+        assert len(result) == 5
+        # Check row count was captured in buffer
+        assert len(monitor._query_buffer) == 1
+        assert monitor._query_buffer[0].row_count == 5
+
+    @pytest.mark.unit
+    def test_decorator_preserves_function_metadata(self):
+        """Decorator preserves function name and docstring."""
+        from performance_monitor import track_query_func
+
+        @track_query_func('my_query', 'select')
+        def documented_function():
+            """This is the docstring."""
+            pass
+
+        assert documented_function.__name__ == 'documented_function'
+        assert documented_function.__doc__ == """This is the docstring."""
+
+
+class TestTrackApiFunc:
+    """Tests for the track_api_func decorator."""
+
+    @pytest.mark.unit
+    def test_decorator_tracks_successful_call(self):
+        """Decorator tracks successful API calls."""
+        from performance_monitor import track_api_func, init_performance_monitoring
+
+        monitor = init_performance_monitoring()
+
+        @track_api_func('test_service', 'test_endpoint')
+        def api_function():
+            return {'status': 'ok'}
+
+        result = api_function()
+
+        assert result == {'status': 'ok'}
+        key = 'test_service:test_endpoint'
+        assert key in monitor._api_stats
+        assert monitor._api_stats[key]['errors'] == 0
+
+    @pytest.mark.unit
+    def test_decorator_tracks_failed_call(self):
+        """Decorator tracks failed API calls."""
+        from performance_monitor import track_api_func, init_performance_monitoring
+
+        monitor = init_performance_monitoring()
+
+        @track_api_func('failing_service', 'failing_endpoint')
+        def failing_function():
+            raise ValueError("API Error")
+
+        with pytest.raises(ValueError):
+            failing_function()
+
+        key = 'failing_service:failing_endpoint'
+        assert key in monitor._api_stats
+        assert monitor._api_stats[key]['errors'] == 1
+
+
+# ============================================================================
+# Test Context Managers
+# ============================================================================
+
+class TestTrackQueryContextManager:
+    """Tests for the track_query context manager."""
+
+    @pytest.mark.unit
+    def test_context_manager_tracks_timing(self):
+        """Context manager tracks execution time."""
+        from performance_monitor import track_query, init_performance_monitoring
+
+        monitor = init_performance_monitoring()
+
+        with track_query('ctx_query', 'select'):
+            time.sleep(0.01)
+
+        assert 'ctx_query' in monitor._query_stats
+
+    @pytest.mark.unit
+    def test_context_manager_handles_exceptions(self):
+        """Context manager records timing even on exception."""
+        from performance_monitor import track_query, init_performance_monitoring
+
+        monitor = init_performance_monitoring()
+
+        with pytest.raises(RuntimeError):
+            with track_query('failing_query', 'select'):
+                raise RuntimeError("Query failed")
+
+        # Should still have recorded the timing
+        assert 'failing_query' in monitor._query_stats
+
+
+class TestTrackApiCallContextManager:
+    """Tests for the track_api_call context manager."""
+
+    @pytest.mark.unit
+    def test_context_manager_tracks_timing(self):
+        """Context manager tracks API call timing."""
+        from performance_monitor import track_api_call, init_performance_monitoring
+
+        monitor = init_performance_monitoring()
+
+        with track_api_call('ctx_service', 'ctx_endpoint'):
+            time.sleep(0.01)
+
+        key = 'ctx_service:ctx_endpoint'
+        assert key in monitor._api_stats
+
+    @pytest.mark.unit
+    def test_context_manager_tracks_failures(self):
+        """Context manager records failures on exception."""
+        from performance_monitor import track_api_call, init_performance_monitoring
+
+        monitor = init_performance_monitoring()
+
+        with pytest.raises(ConnectionError):
+            with track_api_call('failing_api', 'endpoint'):
+                raise ConnectionError("Network error")
+
+        key = 'failing_api:endpoint'
+        assert monitor._api_stats[key]['errors'] == 1
+
+
+# ============================================================================
+# Test Global Monitor Management
+# ============================================================================
+
+class TestGlobalMonitor:
+    """Tests for global monitor initialization and access."""
+
+    @pytest.mark.unit
+    def test_init_creates_global_monitor(self):
+        """init_performance_monitoring creates global monitor."""
+        from performance_monitor import init_performance_monitoring, get_performance_monitor
+
+        monitor = init_performance_monitoring()
+
+        assert get_performance_monitor() is monitor
+
+    @pytest.mark.unit
+    def test_init_with_db_tables(self):
+        """init_performance_monitoring accepts db_tables."""
+        from performance_monitor import init_performance_monitoring
+
+        mock_db = MagicMock()
+        monitor = init_performance_monitoring(db_tables=mock_db)
+
+        assert monitor.db_tables == mock_db
+
+    @pytest.mark.unit
+    def test_get_monitor_returns_none_before_init(self):
+        """get_performance_monitor returns None before initialization."""
+        from performance_monitor import _performance_monitor
+        import performance_monitor
+
+        # Reset global
+        original = performance_monitor._performance_monitor
+        performance_monitor._performance_monitor = None
+
+        result = performance_monitor.get_performance_monitor()
+
+        assert result is None
+
+        # Restore
+        performance_monitor._performance_monitor = original
+
+
+# ============================================================================
+# Test Data Classes
+# ============================================================================
+
+class TestMetricDataClasses:
+    """Tests for metric data classes."""
+
+    @pytest.mark.unit
+    def test_request_metric_creation(self):
+        """RequestMetric dataclass works correctly."""
+        from performance_monitor import RequestMetric
+
+        metric = RequestMetric(
+            route="/test",
+            method="GET",
+            status_code=200,
+            duration_ms=100.5
+        )
+
+        assert metric.route == "/test"
+        assert metric.method == "GET"
+        assert metric.status_code == 200
+        assert metric.duration_ms == 100.5
+        assert metric.timestamp is not None
+
+    @pytest.mark.unit
+    def test_query_metric_creation(self):
+        """QueryMetric dataclass works correctly."""
+        from performance_monitor import QueryMetric
+
+        metric = QueryMetric(
+            query_type="select",
+            query_name="get_users",
+            duration_ms=25.3,
+            row_count=50
+        )
+
+        assert metric.query_type == "select"
+        assert metric.query_name == "get_users"
+        assert metric.row_count == 50
+
+    @pytest.mark.unit
+    def test_api_metric_creation(self):
+        """ApiMetric dataclass works correctly."""
+        from performance_monitor import ApiMetric
+
+        metric = ApiMetric(
+            service="google_books",
+            endpoint="search",
+            duration_ms=500,
+            status_code=200,
+            success=True
+        )
+
+        assert metric.service == "google_books"
+        assert metric.success is True
+
+    @pytest.mark.unit
+    def test_api_metric_with_error(self):
+        """ApiMetric captures error information."""
+        from performance_monitor import ApiMetric
+
+        metric = ApiMetric(
+            service="failing_api",
+            endpoint="broken",
+            duration_ms=100,
+            success=False,
+            error_message="Connection refused"
+        )
+
+        assert metric.success is False
+        assert metric.error_message == "Connection refused"


### PR DESCRIPTION
Add comprehensive performance monitoring to track:
- Request/response timing via middleware
- Database query performance with decorators
- External API call timing (Google Books, Open Library)

Includes new admin dashboard at /admin/performance showing:
- Overview stats (requests, queries, API calls)
- Slowest routes table
- Slowest queries table
- External API performance
- Recent slow requests list

https://claude.ai/code/session_0193R8e75cZAq2G9m3Pi8ixH